### PR TITLE
Added tokenization for WooCommerce 2.6.2 support

### DIFF
--- a/classes/class-cio4wc_gateway.php
+++ b/classes/class-cio4wc_gateway.php
@@ -35,7 +35,8 @@ class CIO4WC_Gateway extends WC_Payment_Gateway {
             'subscription_amount_changes',
             'subscription_date_changes',
             'subscription_payment_method_change',
-            'refunds'
+            'refunds',
+            'tokenization'
         );
 
         // Init settings


### PR DESCRIPTION
Added tokenization string as a supported payment method to provide support with WooCommerce 2.6.2
