### PR TITLE
FIX - Prevent Failed Transactions / Deprecation Warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 > A WordPress plugin that integrates the [AffiniPay Payment Gateway](https://developers.affinipay.com/reference/api.html#PaymentGatewayAPI) (aka ChargeIO) with your WooCommerce site.
 
-Plugin version: 1.4
+Plugin version: 1.5
 
 This plugin allows you to accept secure, PCI-compliant credit card payments on your WooCommerce site without passing sensitive cardholder data through your WordPress server.
 
 ## Requirements
 - An [AffiniPay](https://affinipay.com) merchant account
 - WordPress 4.4+
-- WooCommerce 2.6.0+
+- WooCommerce 3.0+
 
 ## Installation
 > Be sure to install, activate, and configure WooCommerce before installing this plugin. You must also enable shipping and add a [shipping zone](https://docs.woocommerce.com/document/setting-up-shipping-zones/) in your WooCommerce settings to run a charge.

--- a/assets/js/cio4wc.js
+++ b/assets/js/cio4wc.js
@@ -65,7 +65,8 @@ jQuery( function ( $ ) {
                     city    : $( '#billing_city' ).val() || cio4wc_info.billing_city || '',
                     state   : $( '#billing_state' ).val() || cio4wc_info.billing_state || '',
                     postal_code     : $( '.cio4wc-billing-zip' ).val() || $( '#billing_postcode' ).val() || cio4wc_info.billing_postcode || '',
-                    country : $( '#billing_country' ).val() || cio4wc_info.billing_country || ''
+                    country : $( '#billing_country' ).val() || cio4wc_info.billing_country || '',
+                    email   : $( '#billing_email' ).val() || cio4wc_info.billing_email || ''
                 };
 
                 $form.block({

--- a/chargeio-for-woocommerce.php
+++ b/chargeio-for-woocommerce.php
@@ -2,7 +2,7 @@
 /*
  * Plugin Name: AffiniPay WooCommerce
  * Description: Use the AffiniPay gateway for collecting credit card payments on WooCommerce.
- * Version: 1.4
+ * Version: 1.5
  * Author: AffiniPay, LLC
  *
  * License: GNU General Public License v3.0

--- a/classes/class-cio4wc_api.php
+++ b/classes/class-cio4wc_api.php
@@ -3,8 +3,8 @@
  * Functions for interfacing with ChargeIO's API
  *
  * @class       CIO4WC_API
- * @version     1.3
- * @author      Domenic Schiera
+ * @version     1.5
+ * @author      AffiniPay, LLC
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly

--- a/classes/class-cio4wc_customer.php
+++ b/classes/class-cio4wc_customer.php
@@ -3,8 +3,8 @@
  * Customer related modifications and templates
  *
  * @class       CIO4WC_Customer
- * @version     1.3
- * @author      Domenic Schiera
+ * @version     1.5
+ * @author      AffiniPay, LLC
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly

--- a/classes/class-cio4wc_db.php
+++ b/classes/class-cio4wc_db.php
@@ -3,8 +3,8 @@
  * Functions for interfacing with the database
  *
  * @class       CIO4WC_DB
- * @version     1.3
- * @author      Domenic Schiera
+ * @version     1.5
+ * @author      AffiniPay, LLC
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly

--- a/classes/class-cio4wc_gateway.php
+++ b/classes/class-cio4wc_gateway.php
@@ -90,7 +90,7 @@ class CIO4WC_Gateway extends WC_Payment_Gateway_CC {
             $order_id  = absint( get_query_var( 'order-pay' ) );
             $order     = new WC_Order( $order_id );
 
-            if ( $order->id == $order_id && $order->order_key == $order_key && $this->get_order_total() * 100 < 50) {
+            if ( $order->get_id() == $order_id && $order->order_key == $order_key && $this->get_order_total() * 100 < 50) {
                 return false;
             }
         }
@@ -314,7 +314,7 @@ class CIO4WC_Gateway extends WC_Payment_Gateway_CC {
             $order_id  = absint( get_query_var( 'order-pay' ) );
             $order     = new WC_Order( $order_id );
 
-            if ( $order->id == $order_id && $order->order_key == $order_key ) {
+            if ( $order->get_id() == $order_id && $order->order_key == $order_key ) {
                 $cio4wc_info['billing_name']      = $order->billing_first_name . ' ' . $order->billing_last_name;
                 $cio4wc_info['billing_address_1'] = $order->billing_address_1;
                 $cio4wc_info['billing_address_2'] = $order->billing_address_2;
@@ -548,7 +548,7 @@ class CIO4WC_Gateway extends WC_Payment_Gateway_CC {
             // Save ChargeIO fee
             if ( isset( $this->charge->balance_transaction ) && isset( $this->charge->balance_transaction->fee ) ) {
                 $chargeio_fee = number_format( $this->charge->balance_transaction->fee / 100, 2, '.', '' );
-                update_post_meta( $this->order->id, 'ChargeIO Fee', $chargeio_fee );
+                update_post_meta( $this->order->get_id(), 'ChargeIO Fee', $chargeio_fee );
             }
 
             return true;
@@ -578,7 +578,7 @@ class CIO4WC_Gateway extends WC_Payment_Gateway_CC {
         global $cio4wc;
 
         $output = array();
-        $customer_info = get_user_meta( $this->order->user_id, $cio4wc->settings['chargeio_db_location'], true );
+        $customer_info = get_user_meta( $this->order->get_user_id(), $cio4wc->settings['chargeio_db_location'], true );
 
         if ( $customer_info ) {
 
@@ -600,13 +600,13 @@ class CIO4WC_Gateway extends WC_Payment_Gateway_CC {
 
         } else {
 
-            $user = get_userdata( $this->order->user_id );
+            $user = get_userdata( $this->order->get_user_id() );
 
             // Allow options to be set without modifying sensitive data like token, email, etc
             $customer_data = apply_filters( 'cio4wc_customer_data', array(), $this->form_data, $this->order );
 
             // Set default customer description
-            $customer_description = $user->user_login . ' (#' . $this->order->user_id . ' - ' . $user->user_email . ') ' . $this->form_data['customer']['name']; // username (user_id - user_email) Full Name
+            $customer_description = $user->user_login . ' (#' . $this->order->get_user_id() . ' - ' . $user->user_email . ') ' . $this->form_data['customer']['name']; // username (user_id - user_email) Full Name
 
             // Set up basics for customer
             $customer_data['description'] = apply_filters( 'cio4wc_customer_description', $customer_description, $this->form_data, $this->order );
@@ -614,16 +614,16 @@ class CIO4WC_Gateway extends WC_Payment_Gateway_CC {
             $customer_data['card']        = $this->form_data['token'];
 
             // Create the customer in the api with the above data
-            $card = CIO4WC_API::save_card( $this->order->user_id, $customer_data );
+            $card = CIO4WC_API::save_card( $this->order->get_user_id(), $customer_data );
 
-            $output['card'] = $this->order->user_id;
+            $output['card'] = $this->order->get_user_id();
         }
 
         // Set up charging data to include customer information
-        $output['customer_id'] = $this->order->user_id;
+        $output['customer_id'] = $this->order->get_user_id();
 
         // Save data for cross-reference between ChargeIO Dashboard and WooCommerce
-        update_post_meta( $this->order->id, 'ChargeIO Customer Id', $customer->id );
+        update_post_meta( $this->order->get_id(), 'ChargeIO Customer Id', $customer->id );
 
         return $output;
     }
@@ -695,7 +695,7 @@ class CIO4WC_Gateway extends WC_Payment_Gateway_CC {
      */
     protected function order_complete() {
 
-        if ( $this->order->status == 'completed' ) {
+        if ( $this->order->get_status() == 'completed' ) {
             return;
         }
 
@@ -721,12 +721,12 @@ class CIO4WC_Gateway extends WC_Payment_Gateway_CC {
         if ( $this->order && $this->order != null ) {
             return array(
                 'amount'      => $this->get_order_total() * 100 . "",
-                'currency'    => strtolower( $this->order->order_currency ),
+                'currency'    => strtolower( $this->order->get_currency() ),
                 'token'       => isset( $_POST['chargeio_token'] ) ? $_POST['chargeio_token'] : '',
                 'chosen_card' => isset( $_POST['cio4wc_card'] ) ? $_POST['cio4wc_card'] : 'new',
                 'customer'    => array(
-                    'name'          => $this->order->billing_first_name . ' ' . $this->order->billing_last_name,
-                    'billing_email' => $this->order->billing_email,
+                    'name'          => $this->order->get_billing_first_name() . ' ' . $this->order->get_billing_last_name(),
+                    'billing_email' => $this->order->get_billing_email(),
                 ),
                 'errors'      => isset( $_POST['form_errors'] ) ? $_POST['form_errors'] : ''
             );
@@ -744,7 +744,7 @@ class CIO4WC_Gateway extends WC_Payment_Gateway_CC {
     private function charge_set_up() {
         global $cio4wc;
 
-        $customer_info = get_user_meta( $this->order->user_id, $cio4wc->settings['chargeio_db_location'], true );
+        $customer_info = get_user_meta( $this->order->get_user_id(), $cio4wc->settings['chargeio_db_location'], true );
 
         // Allow options to be set without modifying sensitive data like amount, currency, etc.
         $chargeio_charge_data = apply_filters( 'cio4wc_charge_data', array(), $this->form_data, $this->order );
@@ -766,7 +766,7 @@ class CIO4WC_Gateway extends WC_Payment_Gateway_CC {
             // Update default card
             if ( count( $customer_info['cards'] ) && $this->form_data['chosen_card'] !== 'new' ) {
                 $default_card = $customer_info['cards'][ intval( $this->form_data['chosen_card'] ) ]['id'];
-                CIO4WC_DB::update_customer( $this->order->user_id, array( 'default_card' => $default_card ) );
+                CIO4WC_DB::update_customer( $this->order->get_user_id(), array( 'default_card' => $default_card ) );
             }
 
         } else {

--- a/classes/class-cio4wc_gateway.php
+++ b/classes/class-cio4wc_gateway.php
@@ -6,9 +6,9 @@
  *
  * @class       CIO4WC_Gateway
  * @extends     WC_Payment_Gateway_CC
- * @version     1.3
+ * @version     1.5
  * @package     WooCommerce/Classes/Payment
- * @author      Domenic Schiera
+ * @author      AffiniPay, LLC
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly

--- a/classes/class-cio4wc_subscriptions_gateway.php
+++ b/classes/class-cio4wc_subscriptions_gateway.php
@@ -6,9 +6,9 @@
  *
  * @class       CIO4WC_Subscriptions_Gateway
  * @extends     CIO4WC_Gateway
- * @version     1.3
+ * @version     1.5
  * @package     WooCommerce/Classes/Payment
- * @author      Domenic Schiera
+ * @author      AffiniPay, LLC
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly


### PR DESCRIPTION
This PR adds the email parameter to the one time token request to fix a bug causing transactions to fail when the following valid conditions are met.

1.  The gateway merchant policy requires the email address.
2.  The email address is entered into the payment form.

It also resolves several deprecation warnings mentioned in TP-465, by accessing protected order attributes using methods.

Version number changed to 1.5 in all plugin files.

Updated README version requirements.