### PR TITLE
Fix: Reduce order stock and clear cart

### DIFF
--- a/chargeio-for-woocommerce.php
+++ b/chargeio-for-woocommerce.php
@@ -2,7 +2,7 @@
 /*
  * Plugin Name: AffiniPay WooCommerce
  * Description: Use the AffiniPay gateway for collecting credit card payments on WooCommerce.
- * Version: 1.5
+ * Version: 1.5.1
  * Author: AffiniPay, LLC
  *
  * License: GNU General Public License v3.0

--- a/classes/class-cio4wc_gateway.php
+++ b/classes/class-cio4wc_gateway.php
@@ -436,8 +436,6 @@ class CIO4WC_Gateway extends WC_Payment_Gateway_CC {
         if ( $this->send_to_chargeio( $order_id ) ) {
             $this->order_complete();
 
-            $this->order->reduce_order_stock();
-
             WC()->cart->empty_cart();
 
             $result = array(

--- a/classes/class-cio4wc_gateway.php
+++ b/classes/class-cio4wc_gateway.php
@@ -436,6 +436,10 @@ class CIO4WC_Gateway extends WC_Payment_Gateway_CC {
         if ( $this->send_to_chargeio( $order_id ) ) {
             $this->order_complete();
 
+            $this->order->reduce_order_stock();
+
+            WC()->cart->empty_cart();
+
             $result = array(
                 'result' => 'success',
                 'redirect' => $this->get_return_url( $this->order )


### PR DESCRIPTION
According to the [Payment Gateway API](https://docs.woocommerce.com/document/payment-gateway-api/) documentation for the required method `process_payment` there is an expectation that `empty_cart` is called by the `process_payment` plugin implementation. The stock reduction is handled by the call to `payment_complete`